### PR TITLE
Use save-exact for dependencies

### DIFF
--- a/api/.npmrc
+++ b/api/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
Just to ensure pinning pkg versions no matter if we use npm or yarn.